### PR TITLE
fix(package.json): Move workspace dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "react-bndl",
   "version": "1.0.0",
   "description": "A library that allows users to split their React application into multiple bundles and load them each dynamically.",
-  "keywords": ["React", "bundle", "Webpack"],
+  "keywords": [
+    "React",
+    "bundle",
+    "Webpack"
+  ],
   "author": "Bradley Peters",
   "license": "MIT",
   "bugs": "https://github.com/brdlyptrs/react-bndl/issues",
@@ -38,12 +42,12 @@
     "test:end-to-end": "playwright test -c playwright.config.ts"
   },
   "dependencies": {
-    "@bndl/demo": "workspace:^",
-    "@bndl/lib": "workspace:^",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@bndl/demo": "workspace:^",
+    "@bndl/lib": "workspace:^",
     "@playwright/experimental-ct-react": "^1.33.0",
     "@playwright/test": "^1.33.0",
     "@types/node": "^18.11.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bndl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A library that allows users to split their React application into multiple bundles and load them each dynamically.",
   "keywords": [
     "React",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,6 @@ importers:
 
   .:
     dependencies:
-      '@bndl/demo':
-        specifier: workspace:^
-        version: link:demo
-      '@bndl/lib':
-        specifier: workspace:^
-        version: link:lib
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -17,6 +11,12 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
+      '@bndl/demo':
+        specifier: workspace:^
+        version: link:demo
+      '@bndl/lib':
+        specifier: workspace:^
+        version: link:lib
       '@playwright/experimental-ct-react':
         specifier: ^1.33.0
         version: 1.33.0(@types/node@18.11.18)(vite@4.3.8)


### PR DESCRIPTION
#### What
Moves workspace dependencies in root package.json to devDependencies

#### Why
Current dependencies listed at root of repository are required when installing package, and since these are workspace dependencies and not NPM packages they fail to install.